### PR TITLE
오브젝트 풀링 매니저

### DIFF
--- a/Assets/Script/Core/ObjectPool/ObjectPoolManager.cs
+++ b/Assets/Script/Core/ObjectPool/ObjectPoolManager.cs
@@ -1,0 +1,144 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+namespace OneBunny
+{
+    [Serializable]
+    internal struct PoolData
+    {
+        [field: SerializeField] public string Name { get; set; }
+        [field: SerializeField] public GameObject CopyObject { get; set; }
+        [field: SerializeField] public int Size { get; set; }
+        [field: SerializeField] public Transform Container { get; set; }
+    }
+
+    public class ObjectPoolManager : MonoBehaviour
+    {
+        // ObjectPool을 사용할 오브젝트를 보관하는 곳.
+        [SerializeField] private List<PoolData> _poolDataList;
+
+        private Dictionary<string, List<GameObject>> _objectPoolDic;
+        
+        private void Awake()
+        {
+            _objectPoolDic = new Dictionary<string, List<GameObject>>();
+            
+            if (_poolDataList.Count <= 0)
+            {
+                PoolLog("Pool List에 아무것도 존재하지 않습니다.");
+                throw new Exception("No Prefab");
+            }
+
+            SetUp();
+        }
+
+        #region StaticField
+        
+        // obj 오브젝트를 Pool에 추가한다.
+        public static void ReturnToPool(string objName)
+        {
+            // objName에서 분리
+            var splitData = objName.Split(" ");
+            var key = splitData[0];
+            var index = Int32.Parse(splitData[1]);
+            
+            var isHave = Singleton.Instance.poolManager.HaveKeyCheck(key);
+
+            if (!isHave)
+            {
+                return;
+            }
+
+            // Key가 존재할 경우.
+            var pool = Singleton.Instance.poolManager._objectPoolDic[key];
+            pool[index - 1].SetActive(false);
+        }
+
+        public static GameObject Get(string key)
+        {
+            return Singleton.Instance.poolManager.SpawnToPool(key);
+        }
+        
+
+        private static void PoolLog(string text)
+        {
+            Debug.Log($"[Object Pool Manager] {text}");
+        }
+
+        #endregion
+        
+        #region NotStaticField
+        
+        public GameObject SpawnToPool(string key)
+        {
+            var poolObjList = Singleton.Instance.poolManager._poolDataList;
+            var poolDic = Singleton.Instance.poolManager._objectPoolDic;
+            GameObject obj;
+            
+            if (!HaveKeyCheck(key))
+            {
+                PoolLog($"Spawn을 할 수 없습니다.");
+            }
+            
+            // 현재까지 왔다는 것은 해당 key가 있다는 것임.
+            
+            // key에 해당하는 Pool과 Copy Prefab을 가져옴.
+            var keyObj = poolObjList.Find(x => x.Name == key);
+            var pool = poolDic[key];
+
+            // 정해둔 Size를 Pool이 초과하지 않았다면. -> Update에서 쓰일 수 있으므로 방어적 프로그래밍.
+            if (keyObj.Size >= pool.Count)
+            {
+                obj = CreateObject(keyObj.Container, keyObj.CopyObject);
+
+                pool.Add(obj);
+                obj.name = String.Concat($"{keyObj.Name} ", pool.Count.ToString());
+            }
+            else
+            {
+                PoolLog("Pool Size가 정해둔 Size를 초과합니다.");
+                throw new Exception("Pool Size Over");
+            }
+
+            return obj;
+        }
+
+        private GameObject CreateObject(Transform parent, GameObject prefabObj)
+        {
+            var obj = Instantiate(prefabObj, parent);
+            obj.SetActive(false);
+            
+            return obj;
+        }
+        
+        public bool HaveKeyCheck(string key)
+        {
+            var poolObjList = Singleton.Instance.poolManager._poolDataList;
+            // 매개로 전달 받은 Key가 있는 지 확인.
+            foreach (var poolObj in poolObjList)
+            {
+                if (poolObj.Name.Contains(key))
+                {
+                    return true;
+                }
+            }
+            PoolLog($"전달받은 Key인 {key}가 존재하지 않습니다.");
+            throw new Exception("No Key");
+        }
+
+        public void SetUp()
+        {
+            if (_poolDataList.Count > 0)
+            {
+                foreach (var poolData in _poolDataList)
+                {
+                    _objectPoolDic.Add(poolData.Name, new List<GameObject>());
+                }
+            }
+        }
+        
+        #endregion
+    }
+}

--- a/Assets/Script/Core/ObjectPool/ObjectPoolManager.cs
+++ b/Assets/Script/Core/ObjectPool/ObjectPoolManager.cs
@@ -8,10 +8,10 @@ namespace OneBunny
     [Serializable]
     internal struct PoolData
     {
-        [field: SerializeField] public string Name { get; set; }
-        [field: SerializeField] public GameObject CopyObject { get; set; }
-        [field: SerializeField] public int Size { get; set; }
-        [field: SerializeField] public Transform Container { get; set; }
+        [field: SerializeField] public string Name { get; private set; }
+        [field: SerializeField] public GameObject CopyObject { get; private set; }
+        [field: SerializeField] public int Size { get; private set; }
+        [field: SerializeField] public Transform Container { get; private set; }
     }
 
     public class ObjectPoolManager : MonoBehaviour

--- a/Assets/Script/Core/ObjectPool/ObjectPoolManager.cs.meta
+++ b/Assets/Script/Core/ObjectPool/ObjectPoolManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14441f91dbb03014296580a2cb23bf6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Core/Singleton/Singleton.cs
+++ b/Assets/Script/Core/Singleton/Singleton.cs
@@ -1,14 +1,16 @@
 using UnityEngine;
+using UnityEngine.Rendering;
 
 
 namespace OneBunny
 {
-    public abstract class Singleton : MonoBehaviour
+    public class Singleton : MonoBehaviour
     {
         private static Singleton _instance = null;
         private static object _lock = new object();
         private static bool _applicationQuit = false;
 
+        public ObjectPoolManager poolManager;
         public static Singleton Instance
         {
             get
@@ -46,12 +48,12 @@ namespace OneBunny
             }
         }
 
-        protected virtual void OnApplicationQuit()
+        protected void OnApplicationQuit()
         {
             _applicationQuit = true;
         }
 
-        public virtual void OnDestroy()
+        public void OnDestroy()
         {
             _applicationQuit = true;
         }


### PR DESCRIPTION
오브젝트 풀링 매니저 구현
==========
오브젝트 풀링 매니저를 통해서 효율적으로 Object들을 관리할 수 있음.

## 오브젝트 풀링 매니저 인스펙터
![image](https://user-images.githubusercontent.com/44202628/230704019-91831045-e5ee-4039-9c98-267599565956.png)

- Singleton이 달려있는 오브젝트에 Object Pool Manager 추가
- 오브젝트에 Object Pool Manager 추가
  - `Singleton`이 존재하는 오브젝트에 Object Pool Manager가 존재할 필요는 없음 (사진은 예시)

- `ObjectPoolManager` -> `PoolDataList`에 Pooling을 진행할 오브젝트들을 추가 후, 세팅 진행
  - `Name` : Pool의 이름 (이름은 Key값으로 사용됨)
  - `Copy Object` : Pool을 진행할, Prefab 오브젝트
  - `Size` : Pool에서 생성할 최대 오브젝트 수
  - `Container` : Pool 오브젝트를 생성할 부모 `Transform`

## 코드
![image](https://user-images.githubusercontent.com/44202628/230704085-adaff78b-793c-4e55-be8f-6f125c4bea84.png)
- `ObjectPoolManager.Get` : `GameObject`를 리턴하고 해당 `Key`의 오브젝트를 생성함
- `ObjectPoolManager.ReturnToPool` : 해당 오브젝트를 다시 Pool로 돌려보냄.  매개로는 오브젝트 이름을 추가
  - Pool 오브젝트의 이름에는 `Key` + `Index`를 포함함

